### PR TITLE
Adding dockerfile and yaml for deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *~
-/_output/*
+standalone-controller/_output/*
+standalone-executor/_output/*

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,48 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ifeq ($(REGISTRY),)
+	REGISTRY = quay.io/bronhaim/
+endif
+
+ifeq ($(VERSION),)
+	VERSION = latest
+endif
+
+IMAGE_CONTROLLER = $(REGISTRY)standalone-fence-controller:$(VERSION)
+IMAGE_EXECUTOR = $(REGISTRY)standalone-fence-executor:$(VERSION)
+MUTABLE_IMAGE_CONTROLLER = $(REGISTRY)standalone-fence-controller:latest
+MUTABLE_IMAGE_EXECUTOR = $(REGISTRY)standalone-fence-executor:latest
+
 .PHONY: all controller executor clean test
 
 all: controller executor
 
 controller:
-	go build -i -o _output/bin/node-fencing-controller cmd/node-fencing-controller.go
+	go build -i -o standalone-controller/_output/bin/node-fencing-controller cmd/node-fencing-controller.go
 
 executor:
-	go build -i -o _output/bin/node-fencing-executor cmd/node-fencing-executor.go
+	go build -i -o standalone-executor/_output/bin/node-fencing-executor cmd/node-fencing-executor.go
 
 clean:
 	-rm -rf _output
+
+container: controller executor
+	docker build -t $(MUTABLE_IMAGE_CONTROLLER) standalone-controller
+	docker tag $(MUTABLE_IMAGE_CONTROLLER) $(IMAGE_CONTROLLER)
+	docker build -t $(MUTABLE_IMAGE_EXECUTOR) standalone-executor
+	docker tag $(MUTABLE_IMAGE_EXECUTOR) $(IMAGE_EXECUTOR)
 
 test:
 	go test `go list ./... | grep -v 'vendor'`

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 pre-alpha
 
 # Goal
-The goal is to run the controller, filter Pods and find where they are and whether have any PVs. 
+The goal is to run the controller, filter Pods and find where they are and whether have any PVs.
 If nodes that have PVs on them become offline, the fencing controller tries to force detach or even STONITH the node
 
 # Demo
 
 ```console
 # make
-# _output/bin/node-fencing-controller -kubeconfig=/root/.kube/config 
+# standalone-controller/node-fencing-controller -kubeconfig=standalone-controller/config
 
 I1025 14:20:21.175263   23532 controller.go:92] pod controller starting
 I1025 14:20:21.175488   23532 controller.go:94] Waiting for informer initial sync
@@ -26,7 +26,7 @@ I1025 14:33:03.972356   24998 controller.go:294] posted NodeFencing CRD object f
 On a different console:
 
 ```console
-# _output/bin/node-fencing-executor -kubeconfig=/root/.kube/config
+# standalone-executor/node-fencing-executor -kubeconfig=standalone-executor/config
 I1025 14:32:07.029897   24971 executor.go:60] node Fencing executor starting
 I1025 14:32:07.030096   24971 executor.go:62] Waiting for informer initial sync
 I1025 14:32:08.030295   24971 executor.go:70] Watching node fencing object

--- a/standalone-controller/Dockerfile
+++ b/standalone-controller/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM centos:7
+
+ADD _output/bin/node-fencing-controller /
+
+ENTRYPOINT ["/node-fencing-controller"]

--- a/standalone-controller/deployment.yaml
+++ b/standalone-controller/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: standalone-fence-controller
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: standalone-fence-controller
+    spec:
+      containers:
+      - name: standalone-fence-controller
+        image: "quay.io/fence/standalone-fence-controller:latest"
+        imagePullPolicy: IfNotPresent

--- a/standalone-executor/Dockerfile
+++ b/standalone-executor/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM centos:7
+
+ADD _output/bin/node-fencing-executor /
+
+ENTRYPOINT ["/node-fencing-executor"]

--- a/standalone-executor/job.yaml
+++ b/standalone-executor/job.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: executor
+spec:
+  template:
+    metadata:
+      name: executor
+    spec:
+      containers:
+      - name: executor
+        image: quay.io/bronhaim/standalone-fence-executor:latest        
+      restartPolicy: Never
+  backoffLimit: 3


### PR DESCRIPTION
running "make container" will build and tag executor and controller
images. controller is deployed as Deployment config, and executor is a
job that the controller creates in cluster.

Signed-off-by: Yaniv Bronhaim <ybronhei@redhat.com>