### PR TITLE
fixes for current execution flow

### DIFF
--- a/demo/demo-kubernetes-minion-group.yaml
+++ b/demo/demo-kubernetes-minion-group.yaml
@@ -5,43 +5,50 @@ items:
 - kind: ConfigMap
   apiVersion: v1
   metadata:
-   name: fence-config-kubernetes-minion-group-8bjz
+   name: fence-cluster-config
    namespace: default
   data:
    config.properties: |-
-    node_name=kubernetes-minion-group-8bjz
-    isolation=google-cloud
-    power_management=
-    recovery=
+    grace_timeout=10
+    giveup_retries=5
 
 - kind: ConfigMap
   apiVersion: v1
   metadata:
-   name: fence-method-google-cloud-kubernetes-minion-group-8bjz
-   namespace: default
-  data:
-   method.properties: |
-          template=fence-template-google-cloud
-          instance_name=kubernetes-minion-group-8bjz
-
-- kind: ConfigMap
-  apiVersion: v1
-  metadata:
-   name: fence-config-kubernetes-minion-group-n2dw
+   name: fence-config-kubernetes-minion-group-9ssp
    namespace: default
   data:
    config.properties: |-
-    node_name=kubernetes-minion-group-n2dw
-    isolation=google-cloud
-    power_management=
-    recovery=
+    node_name=kubernetes-minion-group-9ssp
+    isolation=cordon
+    power_management=gcloud-reset-inst
+    recovery=uncordon
 
 - kind: ConfigMap
   apiVersion: v1
   metadata:
-   name: fence-method-google-cloud-kubernetes-minion-group-n2dw
+   name: fence-method-gcloud-reset-inst-kubernetes-minion-group-9ssp
    namespace: default
   data:
    method.properties: |
-          template=fence-template-google-cloud
-          instance_name=kubernetes-minion-group-n2dw
+          agent_name=gcloud-reset-inst
+          zone=us-east1-b
+          project=kube-cluster-fence-poc
+
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+   name: fence-method-cordon-kubernetes-minion-group-9ssp
+   namespace: default
+  data:
+   method.properties: |
+          agent_name=cordon
+
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+   name: fence-method-uncordon-kubernetes-minion-group-9ssp
+   namespace: default
+  data:
+   method.properties: |
+          agent_name=uncordon

--- a/demo/templates-fenceconfigs.yaml
+++ b/demo/templates-fenceconfigs.yaml
@@ -59,13 +59,3 @@ items:
           snmp-sec-level=authPriv
           inet4-only=true
 
-- kind: ConfigMap
-  apiVersion: v1
-  metadata:
-   name: fence-template-google-cloud
-   namespace: default
-  data:
-   template.properties: |-
-          agent_name=google-cloud
-          zone=us-east1-b
-          project=kube-cluster-fence-poc

--- a/fence-scripts/k8s_cordon_node.sh
+++ b/fence-scripts/k8s_cordon_node.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+kubectl cordon $1

--- a/fence-scripts/k8s_gce_reboot_instance.py
+++ b/fence-scripts/k8s_gce_reboot_instance.py
@@ -5,7 +5,8 @@ import sys
 compute = googleapiclient.discovery.build('compute', 'v1')
 
 i = compute.instances()
-
 instance_name = sys.argv[1]
-
-i.reset(project="kube-cluster-fence-poc", zone="us-east1-b", instance=instance_name).execute()
+i.reset(project="kube-cluster-fence-poc",
+        zone="us-east1-b",
+        instance=instance_name).execute()
+print('rebooted machine using googleapiclient')

--- a/fence-scripts/k8s_ssh_fence.sh
+++ b/fence-scripts/k8s_ssh_fence.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 echo Running ssh fence to $1
-ssh root@$1 'service kubelet restart'
+ssh -o ConnectTimeout=3 root@$1 'service kubelet restart'
+exit $?
 

--- a/fence-scripts/k8s_uncordon_node.sh
+++ b/fence-scripts/k8s_uncordon_node.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+kubectl uncordon $1


### PR DESCRIPTION
This patches fixes the controller and executor loop. Once nodefence obj
is processed the controller deletes it.

This also add:
- demo-kubernetes-minion-group.yaml which is part of the demo https://www.youtube.com/watch?v=l6B7JsAoh50
- fence agent scripts to source tree - those are just examples.

Signed-off-by: Yaniv Bronhaim <ybronhei@redhat.com>