### PR TITLE
refactor agents from fencing, using cluster-fence-config and modified comments and readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,66 @@
-# Kubernetes Node Fencing Controller
+# Kubernetes Node Fence controller and executor
 
 # Status
 pre-alpha
 
 # Goal
-The goal is to run the controller, filter Pods and find where they are and whether have any PVs.
-If nodes that have PVs on them become offline, the fencing controller tries to force detach or even STONITH the node
+The goal is to run controller that monitors partitioned nodes (i.e. not-ready nodes or nodes that raises problem events)
+Once partitioned is monitored, the controller posts NodeFence CRD object.
+
+Fence is performed in 3 steps: Isolation, Power-Management and Recovery which are part of the nodeFenceConfig for each node
+
+```yaml
+Here we define fence config for node1 which runs "cordon" -> "gcloud-reset-inst" -> "uncordon"
+
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+   name: fence-config-node1
+   namespace: default
+  data:
+   config.properties: |-
+    node_name=node1
+    isolation=cordon
+    power_management=gcloud-reset-inst
+    recovery=uncordon
+
+The controller moves between steps every grace_period which is defined by the fence-cluster-config
+
+- kind: ConfigMap
+  apiVersion: v1
+  metadata:
+   name: fence-cluster-config
+   namespace: default
+  data:
+   config.properties: |-
+    grace_timeout=10
+    giveup_retries=5
+    roles=
+```
 
 # Demo
-
 ```console
 # make
-# standalone-controller/node-fencing-controller -kubeconfig=standalone-controller/config
-
-I1025 14:20:21.175263   23532 controller.go:92] pod controller starting
-I1025 14:20:21.175488   23532 controller.go:94] Waiting for informer initial sync
-I1025 14:20:22.218596   23532 controller.go:103] node controller starting
-I1025 14:20:22.218651   23532 controller.go:105] Waiting for informer initial sync
-W1025 14:33:03.903473   24998 controller.go:156] node node063 Ready status is unknown
-W1025 14:33:03.903515   24998 controller.go:158] PVs on node node063:
-W1025 14:33:03.903544   24998 controller.go:160]        pvc-b9e0e189-b98f-11e7-ae60-00259003b6e8:
-I1025 14:33:03.972356   24998 controller.go:294] posted NodeFencing CRD object for node node063
+# $ ./standalone-controller/_output/bin/node-fencing-controller -kubeconfig=/home/ybronhaim/.kube/config
+  I1228 10:29:01.180885    6376 controller.go:120] Fence controller starting
+  I1228 10:29:01.181089    6376 controller.go:123] Waiting for pod informer initial sync
+  I1228 10:29:02.181297    6376 controller.go:133] Waiting for node informer initial sync
+  I1228 10:29:03.181527    6376 controller.go:144] Waiting for event informer initial sync
+  I1228 10:29:04.335665    6376 controller.go:170] Controller monitor is running every 10 seconds
+   ...
+  W1228 10:34:55.392293    6376 controller.go:272] Node node1-48dw ready status is unknown
+  I1228 10:34:55.547233    6376 controller.go:447] Posted NodeFence CRD object for node node1-48dw - starting Isolation
+  ...
 ```
 
 On a different console:
 
 ```console
-# standalone-executor/node-fencing-executor -kubeconfig=standalone-executor/config
-I1025 14:32:07.029897   24971 executor.go:60] node Fencing executor starting
-I1025 14:32:07.030096   24971 executor.go:62] Waiting for informer initial sync
-I1025 14:32:08.030295   24971 executor.go:70] Watching node fencing object
-I1025 14:33:04.587703   24971 fencing.go:20] fencing output: status :0
-I1025 14:33:04.587763   24971 fencing.go:22] fencing node node063 succeeded
+# $ ./standalone-executor/_output/bin/node-fencing-executor -kubeconfig=/home/ybronhaim/.kube/config
+I1228 10:36:16.764111    7157 executor.go:60] Node fence executor starting
+I1228 10:36:16.764210    7157 executor.go:62] Waiting for informer initial sync
+I1228 10:36:16.920480    7157 executor.go:133] New fence object node1-48dw-fb2a0ae8-eba9-11e7-809c-68f728ac95ea
+ ...
 ```
+
+In https://www.youtube.com/watch?v=l6B7JsAoh50&t we show the full example over GCE k8s cluster

--- a/demo/demo-kubernetes-minion-group.yaml
+++ b/demo/demo-kubernetes-minion-group.yaml
@@ -11,6 +11,7 @@ items:
    config.properties: |-
     grace_timeout=10
     giveup_retries=5
+    roles=
 
 - kind: ConfigMap
   apiVersion: v1

--- a/pkg/apis/crd/v1/types.go
+++ b/pkg/apis/crd/v1/types.go
@@ -182,17 +182,6 @@ const (
 	Select
 )
 
-type Agent struct {
-	// Agent Name
-	Name string
-
-	// Description
-	Desc string
-
-	// command to execute
-	Function func(params map[string]string, node *core_v1.Node) error
-}
-
 type Parameter struct {
 	// Parameter Name
 	Name string

--- a/pkg/fencing/agents.go
+++ b/pkg/fencing/agents.go
@@ -1,0 +1,117 @@
+package fencing
+
+import (
+	"github.com/golang/glog"
+	"fmt"
+	"os/exec"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+type Agent struct {
+	Name string
+	Desc string
+	Function func(params map[string]string, node *apiv1.Node) error
+}
+
+// agents map holds Agent structs. key is the agent_name param in fence method configmap
+
+// e.g. for the following configmap agent_name is gcloud-reset-inst
+// In agents map we should have entry for "gcloud-reset-inst". In Agent.Function value
+// we set pointer to the implementation (gceAgentFunc)
+
+//- kind: ConfigMap
+//  apiVersion: v1
+//  metadata:
+//  	name: fence-method-gcloud-reset-inst-kubernetes-minion-group-9ssp
+//  	namespace: default
+//	data:
+//		method.properties: |
+//			agent_name=gcloud-reset-inst
+//			zone=us-east1-b
+//			project=kube-cluster-fence-poc
+
+var agents = make(map[string]Agent)
+
+func init() {
+	// Register agents
+	// For each agent_name we define description and function pointer for the execution logic
+	agents["ssh"] = Agent{
+		Name:     "ssh",
+		Desc:     "Agent login to host via ssh and restart kubelet - requires copy-id first to allow root login",
+		Function: sshFenceAgentFunc,
+	}
+	agents["fence_apc_snmp"] = Agent{
+		Name:     "fence_apc_snmp",
+		Desc:     "Fence agent for APC, Tripplite PDU over SNMP",
+		Function: apcSNMPAgentFunc,
+	}
+	agents["gcloud-reset-inst"] = Agent{
+		Name:     "google-cloud",
+		Desc:     "Reboot instance in GCE cluster",
+		Function: gceAgentFunc,
+	}
+
+	agents["cordon"] = Agent{
+		Name:     "cordon",
+		Desc:     "Stop scheduler from using resources on node",
+		Function: cordonFunc,
+	}
+	agents["uncordon"] = Agent{
+		Name:     "uncordon",
+		Desc:     "Remove cordon from node",
+		Function: uncordonFunc,
+	}
+}
+
+func cordonFunc(params map[string]string, node *apiv1.Node) error {
+	cmd := exec.Command("/bin/sh",
+		"fence-scripts/k8s_cordon_node.sh",
+		node.Name)
+	return waitExec(cmd)
+}
+
+func uncordonFunc(params map[string]string, node *apiv1.Node) error {
+	cmd := exec.Command("/bin/sh",
+		"fence-scripts/k8s_uncordon_node.sh",
+		node.Name)
+	return waitExec(cmd)
+}
+
+func gceAgentFunc(params map[string]string, node *apiv1.Node) error {
+	cmd := exec.Command("/usr/bin/python",
+		"fence-scripts/k8s_gce_reboot_instance.py",
+		node.Name)
+	return waitExec(cmd)
+}
+
+func waitExec(cmd *exec.Cmd) error {
+	WaitTimeout(cmd, 3000)
+	output, err := cmd.CombinedOutput()
+	glog.Infof("Agent output: %s", string(output))
+	return err
+}
+
+func sshFenceAgentFunc(params map[string]string, node *apiv1.Node) error {
+	add := node.Status.Addresses[0].Address
+	cmd := exec.Command("/bin/sh", "fence-scripts/k8s_ssh_fence.sh", add)
+	return waitExec(cmd)
+}
+
+func apcSNMPAgentFunc(params map[string]string, _ *apiv1.Node) error {
+	ip := fmt.Sprintf("--ip=%s", params["address"])
+	username := fmt.Sprintf("--username=%s", params["username"])
+	password := fmt.Sprintf("--password=%s", params["password"])
+	plug := fmt.Sprintf("--plug=%s", params["plug"])
+	action := fmt.Sprintf("--action=%s", params["action"])
+
+	cmd := exec.Command(
+		"/usr/bin/python",
+		"/usr/sbin/fence_apc_snmp",
+		ip,
+		password,
+		username,
+		plug,
+		action,
+	)
+	return waitExec(cmd)
+}

--- a/pkg/fencing/fencing.go
+++ b/pkg/fencing/fencing.go
@@ -3,11 +3,7 @@ package fencing
 import (
 	"errors"
 	"fmt"
-	"os/exec"
 	"strings"
-	"syscall"
-	"time"
-
 	"github.com/golang/glog"
 	crdv1 "github.com/rootfs/node-fencing/pkg/apis/crd/v1"
 	"k8s.io/api/core/v1"
@@ -15,95 +11,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-var agents = make(map[string]crdv1.Agent)
-
-func init() {
-	// register agents
-	agents["ssh"] = crdv1.Agent{
-		Name:     "ssh",
-		Desc:     "Agent login to host via ssh and restart kubelet - requires copy-id first to allow root login",
-		Function: sshFenceAgentFunc,
-	}
-	agents["fence_apc_snmp"] = crdv1.Agent{
-		Name:     "fence_apc_snmp",
-		Desc:     "Fence agent for APC, Tripplite PDU over SNMP",
-		Function: apcSNMPAgentFunc,
-	}
-	agents["gcloud-reset-inst"] = crdv1.Agent{
-		Name:     "google-cloud",
-		Desc:     "Reboot instance in GCE cluster",
-		Function: gceAgentFunc,
-	}
-
-	agents["cordon"] = crdv1.Agent{
-		Name:     "cordon",
-		Desc:     "Stop scheduler from using resources on node",
-		Function: cordonFunc,
-	}
-	agents["uncordon"] = crdv1.Agent{
-		Name:     "uncordon",
-		Desc:     "Remove cordon from node",
-		Function: uncordonFunc,
-	}
-}
-
-func cordonFunc(params map[string]string, node *v1.Node) error {
-	cmd := exec.Command("/bin/sh",
-		"fence-scripts/k8s_cordon_node.sh",
-		node.Name)
-	return waitExec(cmd)
-}
-
-func uncordonFunc(params map[string]string, node *v1.Node) error {
-	cmd := exec.Command("/bin/sh",
-		"fence-scripts/k8s_uncordon_node.sh",
-		node.Name)
-	return waitExec(cmd)
-}
-
-func gceAgentFunc(params map[string]string, node *v1.Node) error {
-	cmd := exec.Command("/usr/bin/python",
-		"fence-scripts/k8s_gce_reboot_instance.py",
-		node.Name)
-	return waitExec(cmd)
-}
-
-func waitExec(cmd *exec.Cmd) error {
-	WaitTimeout(cmd, 3000)
-	output, err := cmd.CombinedOutput()
-	glog.Infof("Agent output: %s", string(output))
-	return err
-}
-
-func sshFenceAgentFunc(params map[string]string, node *v1.Node) error {
-	add := node.Status.Addresses[0].Address
-	cmd := exec.Command("/bin/sh", "fence-scripts/k8s_ssh_fence.sh", add)
-	return waitExec(cmd)
-}
-
-func apcSNMPAgentFunc(params map[string]string, _ *v1.Node) error {
-	ip := fmt.Sprintf("--ip=%s", params["address"])
-	username := fmt.Sprintf("--username=%s", params["username"])
-	password := fmt.Sprintf("--password=%s", params["password"])
-	plug := fmt.Sprintf("--plug=%s", params["plug"])
-	action := fmt.Sprintf("--action=%s", params["action"])
-
-	cmd := exec.Command(
-		"/usr/bin/python",
-		"/usr/sbin/fence_apc_snmp",
-		ip,
-		password,
-		username,
-		plug,
-		action,
-	)
-	return waitExec(cmd)
-}
-
-// GetNodeFenceConfig find the nodefenceconfig obj relate to nodeName
+// GetNodeFenceConfig find the configmap obj relate to nodeName.
+// configmap for nodes starts with "fence-config-" concat with nodeName.
+// The function returns NodeFenceConfig filled with method lists for each fence step.
 func GetNodeFenceConfig(nodeName string, c kubernetes.Interface) (crdv1.NodeFenceConfig, error) {
 	fenceConfigName := "fence-config-" + nodeName
-	nodeFields := getConfigValues(fenceConfigName, "config.properties", c)
+	nodeFields := GetConfigValues(fenceConfigName, "config.properties", c)
 	if nodeFields == nil {
 		return crdv1.NodeFenceConfig{}, errors.New("failed to read fence config for node")
 	}
@@ -116,7 +29,9 @@ func GetNodeFenceConfig(nodeName string, c kubernetes.Interface) (crdv1.NodeFenc
 	return config, nil
 }
 
-// ExecuteFenceAgents gets fenceconfig and step, parse it, and calls executeFence
+// ExecuteFenceAgents gets NodeFenceConfig and the step to run.
+// The function iterates over methods' names, fetch their parameters and
+// executes the function related to the method
 func ExecuteFenceAgents(config crdv1.NodeFenceConfig, step crdv1.NodeFenceStepType, c kubernetes.Interface) error {
 	glog.Infof("Running fence execution for node %s, step %s", config.NodeName, step)
 	methods := []string{}
@@ -129,84 +44,50 @@ func ExecuteFenceAgents(config crdv1.NodeFenceConfig, step crdv1.NodeFenceStepTy
 	case crdv1.NodeFenceStepRecovery:
 		methods = config.Recovery
 	default:
-		glog.Errorf("step is invalid %s", step)
-		return errors.New("invalid step parameter")
+		return errors.New("ExecuteFenceAgents::Invalid step parameter")
 	}
 
 	for _, method := range methods {
 		if method == "" {
-			glog.Infof("Nothing to execute in step %s", step)
+			glog.Infof("ExecuteFenceAgents::Nothing to execute in step %s", step)
 			return nil
 		}
 		params := getMethodParams(config.NodeName, method, c)
 		// find template if exists and add its fields
 		if temp, exists := params["template"]; exists {
-			tempParams := getConfigValues(temp, "template.properties", c)
+			tempParams := GetConfigValues(temp, "template.properties", c)
 			for k, v := range tempParams {
 				params[k] = v
 			}
 		}
-		glog.Infof("Executing method: %s", method)
+		glog.Infof("ExecuteFenceAgents::Executing method: %s", method)
 		node, err := c.CoreV1().Nodes().Get(config.NodeName, metav1.GetOptions{})
 		if err != nil {
-			glog.Errorf("Failed to get node: %s", err)
+			glog.Errorf("ExecuteFenceAgents::Failed to get node: %s", err)
 			return err
 		}
 		return executeFence(params, node)
 	}
-	glog.Infof("Finish execution for node: %s", config.NodeName)
+	glog.Infof("ExecuteFenceAgents::Finish execution for node: %s", config.NodeName)
 	return nil
 }
 
+// executeFence calls function related to agent_name in the method parameters
 func executeFence(params map[string]string, node *v1.Node) error {
 	if agentName, exists := params["agent_name"]; exists {
 		if agent, exists := agents[agentName]; exists {
 			if exists != true {
-				return errors.New("failed to find agent")
+				return errors.New(fmt.Sprintf("executeFence::failed to find agent_name %s", agentName))
 			}
 			return agent.Function(params, node)
 		}
 	}
-	return errors.New("configured agent_name does not exist.")
+	return errors.New("executeFence::agent_name parameter does not exist in fence method configuration")
 }
 
+// getMethodParams returns map with the fence-method-[methodName]-[nodeName] parameters
 func getMethodParams(nodeName string, methodName string, c kubernetes.Interface) map[string]string {
 	methodFullName := "fence-method-" + methodName + "-" + nodeName
-	return getConfigValues(methodFullName, "method.properties", c)
+	return GetConfigValues(methodFullName, "method.properties", c)
 }
 
-func getConfigValues(configName string, configType string, c kubernetes.Interface) map[string]string {
-	config, err := c.CoreV1().ConfigMaps("default").Get(configName, metav1.GetOptions{})
-	if err != nil {
-		glog.Errorf("failed to get %s", err)
-		return nil
-	}
-	properties, _ := config.Data[configType]
-	fields := make(map[string]string)
-
-	for _, prop := range strings.Split(properties, "\n") {
-		param := strings.Split(prop, "=")
-		if len(param) == 2 {
-			fields[param[0]] = param[1]
-		}
-	}
-	return fields
-}
-
-// WaitTimeout waits for cmd to exist, if time pass pass sigkill signal
-func WaitTimeout(cmd *exec.Cmd, timeout time.Duration) (err error) {
-	ch := make(chan error)
-	go func() {
-		ch <- cmd.Wait()
-	}()
-	timer := time.NewTimer(timeout)
-	select {
-	case <-timer.C:
-		cmd.Process.Signal(syscall.SIGKILL)
-		close(ch)
-		return errors.New("execute timeout")
-	case err = <-ch:
-		timer.Stop()
-		return err
-	}
-}

--- a/pkg/fencing/utils.go
+++ b/pkg/fencing/utils.go
@@ -1,0 +1,49 @@
+package fencing
+
+import (
+	"github.com/golang/glog"
+	"time"
+	"strings"
+	"errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"syscall"
+	"os/exec"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetConfigValues returns map with the configName and configType parameters
+func GetConfigValues(configName string, configType string, c kubernetes.Interface) map[string]string {
+	config, err := c.CoreV1().ConfigMaps("default").Get(configName, metav1.GetOptions{})
+	if err != nil {
+		glog.Errorf("failed to get %s", err)
+		return nil
+	}
+	properties, _ := config.Data[configType]
+	fields := make(map[string]string)
+
+	for _, prop := range strings.Split(properties, "\n") {
+		param := strings.Split(prop, "=")
+		if len(param) == 2 {
+			fields[param[0]] = param[1]
+		}
+	}
+	return fields
+}
+
+// WaitTimeout waits for cmd to exist, if time pass pass sigkill signal
+func WaitTimeout(cmd *exec.Cmd, timeout time.Duration) (err error) {
+	ch := make(chan error)
+	go func() {
+		ch <- cmd.Wait()
+	}()
+	timer := time.NewTimer(timeout)
+	select {
+	case <-timer.C:
+		cmd.Process.Signal(syscall.SIGKILL)
+		close(ch)
+		return errors.New("execute timeout")
+	case err = <-ch:
+		timer.Stop()
+		return err
+	}
+}


### PR DESCRIPTION
- using cluster-fence-config
- adding more comments
- change readme to fit current behavior
- creating utils.go and agents.go to simplify the code structure
    
Signed-off-by: Yaniv Bronhaim <ybronhei@redhat.com>
