### PR TITLE
Adding "fetch password from secret" script mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifeq ($(VERSION),)
 endif
 
 IMAGE_CONTROLLER = $(REGISTRY)standalone-fence-controller:$(VERSION)
-MUTABLE_IMAGE_CONTROLLER = $(REGISTRY)standalone-fence-controller:latest
+IMAGE_AGENT = $(REGISTRY)agent-image:$(VERSION)
 
 .PHONY: all controller clean test
 
@@ -33,9 +33,12 @@ controller:
 clean:
 	-rm -rf _output
 
-container: controller
-	docker build -t $(MUTABLE_IMAGE_CONTROLLER) standalone-controller
-	docker tag $(MUTABLE_IMAGE_CONTROLLER) $(IMAGE_CONTROLLER)
+images: controller
+	docker build -t $(IMAGE_CONTROLLER) standalone-controller
+	docker tag $(IMAGE_CONTROLLER) $(IMAGE_CONTROLLER)
+	docker build -t $(IMAGE_AGENT) agent-job-image
+	docker tag $(IMAGE_AGENT) $(IMAGE_AGENT)
+
 
 test:
 	go test `go list ./... | grep -v 'vendor'`

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ all: controller
 
 controller:
 	go build -i -o standalone-controller/_output/bin/node-fencing-controller cmd/node-fencing-controller.go
+	go build -o agent-job-image/plugged-fence-agents/fetch_passwd cmd/fetch-password.go
 
 clean:
 	-rm -rf _output

--- a/agent-job-image/Dockerfile
+++ b/agent-job-image/Dockerfile
@@ -15,6 +15,8 @@
 # Base image for fencing job
 FROM centos:7
 
+RUN yum upgrade -y;
+
 RUN yum install fence-agents* -y; yum clean all
 
 # copying plugged fence agents

--- a/cmd/fetch-password.go
+++ b/cmd/fetch-password.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/golang/glog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"encoding/base64"
+)
+
+func main() {
+	kubeconfig := flag.String("kubeconfig", "", "Path to a kubeconfig file")
+
+	flag.Set("logtostderr", "true")
+	flag.Parse()
+
+	// Create the client config. Use kubeconfig if given, otherwise assume in-cluster
+	config, err := buildConfig(*kubeconfig)
+	if err != nil {
+		panic(err)
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		glog.Fatalf("Failed to create kubernetes client: %v", err)
+	}
+	if os.Getenv("SECRET_NAME") == "" {
+		glog.Fatal("SECRET_NAME env var is not set")
+	}
+
+	secret, err := client.CoreV1().Secrets("default").Get(os.Getenv("SECRET_NAME"), metav1.GetOptions{})
+	if err != nil {
+		glog.Fatalf("failed to read secret from apiserver: %v", err)
+	}
+
+	encPass := base64.StdEncoding.EncodeToString([]byte(secret.Data["password"]))
+	passDec, err := base64.StdEncoding.DecodeString(encPass)
+	if err != nil {
+		glog.Fatalf("error in decoding: %v", err)
+	}
+	fmt.Printf("%s\n", passDec)
+}
+
+func buildConfig(kubeconfig string) (*rest.Config, error) {
+	if kubeconfig != "" {
+		return clientcmd.BuildConfigFromFlags("", kubeconfig)
+	}
+	return rest.InClusterConfig()
+}

--- a/pkg/fencing/fencing.go
+++ b/pkg/fencing/fencing.go
@@ -29,5 +29,8 @@ func GetNodeFenceConfig(nodeName string, c kubernetes.Interface) (crdv1.NodeFenc
 // GetMethodParams returns map with the fence-method-[methodName]-[nodeName] parameters
 func GetMethodParams(nodeName string, methodName string, c kubernetes.Interface) map[string]string {
 	methodFullName := "fence-method-" + methodName + "-" + nodeName
-	return GetConfigValues(methodFullName, "method.properties", c)
+	params := GetConfigValues(methodFullName, "method.properties", c)
+	// keep method-name to compone secret related to method
+	params["method_name"] = methodFullName
+	return params
 }

--- a/standalone-controller/Dockerfile
+++ b/standalone-controller/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# image is based on agent-image to include all fence-agent scripts for metadata parsing
 FROM docker.io/bronhaim/agent-image
 
 ADD _output/bin/node-fencing-controller /

--- a/standalone-controller/Dockerfile
+++ b/standalone-controller/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # image is based on agent-image to include all fence-agent scripts for metadata parsing
-FROM docker.io/bronhaim/agent-image
+FROM quay.io/bronhaim/agent-image
 
 ADD _output/bin/node-fencing-controller /
 

--- a/standalone-controller/fence-controller-deployment.yaml
+++ b/standalone-controller/fence-controller-deployment.yaml
@@ -1,4 +1,4 @@
-# RBAC
+# RBAC for fence-controller pod
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -85,3 +85,39 @@ spec:
         - name: standalone-fence-controller
           image: "quay.io/bronhaim/standalone-fence-controller:latest"
           imagePullPolicy: Always
+---
+# RBAC for fence agent pod
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fence-agent
+  namespace: default
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - "*"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fence-agent
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: fence-agent
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: fence-agent
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: fence-agent
+    namespace: default
+---
+


### PR DESCRIPTION
This patch adds simple go process that runs as part of the agent pod with service account that allows it to get secrets object from apiserver. This is done to avoid passing plain-text password as part of the request.
To enable encryption in etcd when secret is stored, EncryptionConfig should be set properly (https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/)