### PR TITLE
Change base image for fence agents

### DIFF
--- a/agent-job-image/Dockerfile
+++ b/agent-job-image/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Base image for fencing job
-FROM centos:7
+FROM fedora:28
 
 RUN yum upgrade -y;
 


### PR DESCRIPTION
CentOS doesn't have fence agent for the Google Cloud. Fedora already has it.